### PR TITLE
fixed log_weight function and changed dlogp naming

### DIFF
--- a/bgflow/bg.py
+++ b/bgflow/bg.py
@@ -13,14 +13,14 @@ def unnormalized_kl_div(prior, flow, target, n_samples, temperature=1.0):
 
 
 def unormalized_nll(prior, flow, *x, temperature=1.0):
-    *z, dlogp = flow(*x, inverse=True, temperature=temperature)
-    return prior.energy(*z, temperature=temperature) - dlogp
+    *z, neg_dlogp = flow(*x, inverse=True, temperature=temperature)
+    return prior.energy(*z, temperature=temperature) - neg_dlogp
 
 
 def log_weights(*x, prior, flow, target, temperature=1.0):
-    *z, dlogp = flow(*x, inverse=True, temperature=temperature)
+    *z, neg_dlogp = flow(*x, inverse=True, temperature=temperature)
     return log_weights_given_latent(
-        x, z, dlogp, prior, flow, target, temperature=temperature
+        x, z, -neg_dlogp, prior, flow, target, temperature=temperature
     )
 
 

--- a/bgflow/bg.py
+++ b/bgflow/bg.py
@@ -41,7 +41,7 @@ def log_weights_given_latent(x, z, dlogp, prior, target, temperature=1.0, normal
 
 def effective_sample_size(log_weights):
     """Kish effective sample size; log weights don't have to be normalized"""
-    return torch.exp(2*torch.logsumexp(log_weights, dim=0) - torch.logsumexp(2*log_weights, dim=0)).item()
+    return torch.exp(2*torch.logsumexp(log_weights, dim=0) - torch.logsumexp(2*log_weights, dim=0))
 
 
 def sampling_efficiency(log_weights):

--- a/bgflow/bg.py
+++ b/bgflow/bg.py
@@ -20,11 +20,11 @@ def unormalized_nll(prior, flow, *x, temperature=1.0):
 def log_weights(*x, prior, flow, target, temperature=1.0):
     *z, neg_dlogp = flow(*x, inverse=True, temperature=temperature)
     return log_weights_given_latent(
-        x, z, -neg_dlogp, prior, flow, target, temperature=temperature
+        x, z, -neg_dlogp, prior, target, temperature=temperature
     )
 
 
-def log_weights_given_latent(x, z, dlogp, prior, flow, target, temperature=1.0):
+def log_weights_given_latent(x, z, dlogp, prior, target, temperature=1.0):
     if isinstance(x, torch.Tensor):
         x = (x,)
     if isinstance(z, torch.Tensor):
@@ -123,7 +123,7 @@ class BoltzmannGenerator(Energy, Sampler):
 
     def log_weights_given_latent(self, x, z, dlogp, temperature=1.0):
         return log_weights_given_latent(
-            x, z, dlogp, self._prior, self._flow, self._target, temperature=temperature
+            x, z, dlogp, self._prior, self._target, temperature=temperature
         )
 
     def trigger(self, function_name):

--- a/bgflow/bg.py
+++ b/bgflow/bg.py
@@ -40,12 +40,12 @@ def log_weights_given_latent(x, z, dlogp, prior, target, temperature=1.0, normal
 
 
 def effective_sample_size(log_weights):
-    """Kish effective sample size"""
+    """Kish effective sample size; log weights don't have to be normalized"""
     return torch.exp(2*torch.logsumexp(log_weights, dim=0) - torch.logsumexp(2*log_weights, dim=0)).item()
 
 
 def sampling_efficiency(log_weights):
-    """Kish effective sample size / sample size"""
+    """Kish effective sample size / sample size; log weights don't have to be normalized"""
     return effective_sample_size(log_weights) / len(log_weights)
 
 

--- a/tests/test_bg.py
+++ b/tests/test_bg.py
@@ -88,9 +88,13 @@ def test_bg_metrics(ctx, is_flow_exact):
             atol=1e-4
         )
         effsize = effective_sample_size(logw)
-        assert is_flow_exact == math.isclose(effsize, len(logw), rel_tol=1e-5, abs_tol=1e-4)
+        assert is_flow_exact == torch.allclose(
+            effsize, torch.tensor(10., **ctx), atol=1e-4
+        )
         seff = sampling_efficiency(logw)
-        assert is_flow_exact == math.isclose(seff, 1, rel_tol=1e-5, abs_tol=1e-4)
+        assert is_flow_exact == torch.allclose(
+            seff, torch.ones_like(seff), atol=1e-4
+        )
 
     ## nll (gradient)
     opt = torch.optim.Adam(flow.parameters(), lr=1e-3)

--- a/tests/test_bg.py
+++ b/tests/test_bg.py
@@ -1,7 +1,122 @@
 """Integration test for BoltzmannGenerator class"""
 
 
+import pytest
+import math
 import torch
+from bgflow.distribution.normal import NormalDistribution
+from bgflow.distribution import TorchDistribution
+from bgflow.nn.flow.base import Flow
+from bgflow.bg import (
+    BoltzmannGenerator, unnormalized_kl_div, unormalized_nll,
+    log_weights, log_weights_given_latent
+)
+
+
+@pytest.mark.parametrize("is_flow_exact", [True, False])
+def test_bg_metrics(ctx, is_flow_exact):
+    """Test Boltzmann generator metrics by transforming
+    one normal distribution into another by a linear transformation.
+    """
+    torch.manual_seed(12345)
+
+    # prior = standard normal
+    prior = TorchDistribution(
+        torch.distributions.Independent(
+            torch.distributions.Normal(torch.tensor((0.,), **ctx), torch.tensor((1.,), **ctx)),
+            1
+        )
+    )
+    # target = (scale * standard normal + shift)
+    target = TorchDistribution(
+        torch.distributions.Independent(
+            torch.distributions.Normal(torch.tensor((1.,), **ctx), torch.tensor((2.,), **ctx)),
+            1
+        )
+    )
+
+    class Shift(Flow):
+        def __init__(self, shift=1.0, scale=2.0):
+            super().__init__()
+            self.shift = torch.nn.Parameter(torch.tensor(shift))
+            self.logscale = torch.nn.Parameter(torch.tensor(math.log(scale)))
+
+        def _forward(self, x, **kwargs):
+            return self.logscale.exp()*x + self.shift, self.logscale*torch.ones_like(x).sum(dim=-1, keepdim=True)
+
+        def _inverse(self, x, **kwargs):
+            return (x - self.shift)/self.logscale.exp(), -self.logscale*torch.ones_like(x).sum(dim=-1, keepdim=True)
+
+    shift = 1. if is_flow_exact else 5.0
+    scale = 2. if is_flow_exact else 0.01
+    flow = Shift(shift, scale).to(**ctx)
+    gen = BoltzmannGenerator(prior, flow, target)
+
+    with torch.no_grad():
+        z = prior.sample(10)
+        x, dlogp = flow.forward(z)
+
+        # energies
+        assert is_flow_exact == torch.allclose(
+            prior.energy(z) + dlogp,
+            target.energy(x)
+        )
+        assert is_flow_exact == torch.allclose(
+            gen.energy(x),
+            target.energy(x)
+        )
+
+        # weights
+        logw = log_weights(x, prior=prior, flow=flow, target=target)
+        assert is_flow_exact == torch.allclose(
+            logw, torch.log(1/len(logw)*torch.ones_like(logw)),
+            atol=1e-4
+        )
+        assert torch.allclose(
+            logw,
+            log_weights_given_latent(x, z, dlogp, prior, target),
+            atol=1e-4
+        )
+        assert torch.allclose(
+            logw,
+            gen.log_weights(x),
+            atol=1e-4,
+        )
+        assert torch.allclose(
+            logw,
+            gen.log_weights_given_latent(x, z, dlogp),
+            atol=1e-4
+        )
+
+    ## nll (gradient)
+    opt = torch.optim.Adam(flow.parameters(), lr=1e-3)
+    opt.zero_grad()
+    x = target.sample(1000)
+    nll = unormalized_nll(prior, flow, x)
+    assert torch.allclose(
+        nll,
+        gen.energy(x)
+    )
+    nll.mean().backward()
+    # -- optimal gradients
+    assert is_flow_exact == torch.allclose(flow.shift.grad, torch.zeros_like(flow.shift.grad), atol=1e-1)
+    assert is_flow_exact == torch.allclose(flow.logscale.grad, torch.zeros_like(flow.logscale.grad), atol=1e-1)
+
+    ## kld gradient
+    opt.zero_grad()
+    kld = unnormalized_kl_div(prior, flow, target, 1000)
+    kld.mean().backward()
+    # -- optimal gradients
+    assert is_flow_exact == torch.allclose(flow.shift.grad, torch.zeros_like(flow.shift.grad), atol=1e-1)
+    assert is_flow_exact == torch.allclose(flow.logscale.grad, torch.zeros_like(flow.logscale.grad), atol=1e-1)
+
+    ## generator.kld
+    opt.zero_grad()
+    kld = gen.kldiv(1000)
+    kld.mean().backward()
+    # -- optimal gradients
+    assert is_flow_exact == torch.allclose(flow.shift.grad, torch.zeros_like(flow.shift.grad), atol=1e-1)
+    assert is_flow_exact == torch.allclose(flow.logscale.grad, torch.zeros_like(flow.logscale.grad), atol=1e-1)
 
 
 def test_bg_basic(device, dtype):

--- a/tests/test_bg.py
+++ b/tests/test_bg.py
@@ -9,7 +9,7 @@ from bgflow.distribution import TorchDistribution
 from bgflow.nn.flow.base import Flow
 from bgflow.bg import (
     BoltzmannGenerator, unnormalized_kl_div, unormalized_nll,
-    log_weights, log_weights_given_latent
+    log_weights, log_weights_given_latent, sampling_efficiency, effective_sample_size
 )
 
 
@@ -86,6 +86,14 @@ def test_bg_metrics(ctx, is_flow_exact):
             logw,
             gen.log_weights_given_latent(x, z, dlogp),
             atol=1e-4
+        )
+        effsize = effective_sample_size(logw)
+        assert is_flow_exact == torch.allclose(
+            effsize, torch.tensor(10., **ctx), atol=1e-4
+        )
+        seff = sampling_efficiency(logw)
+        assert is_flow_exact == torch.allclose(
+            seff, torch.ones_like(seff), atol=1e-4
         )
 
     ## nll (gradient)

--- a/tests/test_bg.py
+++ b/tests/test_bg.py
@@ -88,13 +88,9 @@ def test_bg_metrics(ctx, is_flow_exact):
             atol=1e-4
         )
         effsize = effective_sample_size(logw)
-        assert is_flow_exact == torch.allclose(
-            effsize, torch.tensor(10., **ctx), atol=1e-4
-        )
+        assert is_flow_exact == math.isclose(effsize, len(logw), rel_tol=1e-5, abs_tol=1e-4)
         seff = sampling_efficiency(logw)
-        assert is_flow_exact == torch.allclose(
-            seff, torch.ones_like(seff), atol=1e-4
-        )
+        assert is_flow_exact == math.isclose(seff, 1, rel_tol=1e-5, abs_tol=1e-4)
 
     ## nll (gradient)
     opt = torch.optim.Adam(flow.parameters(), lr=1e-3)


### PR DESCRIPTION
This fixes the wrong sign in the log_weights function of the bg class.
Also, as discussed with @Olllom, it introduces this naming convention: `dlogp` for flows from prior to target and `neg_dlogp` for inverse flows
