### PR TITLE
wrapper for torch.distributions.Transform

### DIFF
--- a/bgflow/nn/flow/__init__.py
+++ b/bgflow/nn/flow/__init__.py
@@ -20,3 +20,4 @@ from .triangular import *
 from .pppp import *
 from .diffeq import DiffEqFlow
 from .cdf import *
+from .torchtransform import *

--- a/bgflow/nn/flow/torchtransform.py
+++ b/bgflow/nn/flow/torchtransform.py
@@ -1,0 +1,35 @@
+
+import torch
+from .base import Flow
+
+
+__all__ = ["TorchTransform"]
+
+
+class TorchTransform(Flow):
+    """Wrap a torch.distributions.Transform as a Flow instance
+
+    Parameters
+    ----------
+    transform : torch.distributions.Transform
+        The transform instance that should be wrapped as a Flow instance.
+    reinterpreted_batch_ndims : int, optional
+        Number of batch dimensions to be reinterpreted as event dimensions.
+        If >0, this transform is wrapped in an torch.distributions.IndependentTransform instance.
+    """
+
+    def __init__(self, transform, reinterpreted_batch_ndims=0):
+        super().__init__()
+        if reinterpreted_batch_ndims > 0:
+            transform = torch.distributions.IndependentTransform(transform, reinterpreted_batch_ndims)
+        self._delegate_transform = transform
+
+    def _forward(self, x, **kwargs):
+        y = self._delegate_transform(x)
+        dlogp = self._delegate_transform.log_abs_det_jacobian(x, y)
+        return y, dlogp[..., None]
+
+    def _inverse(self, y, **kwargs):
+        x = self._delegate_transform.inv(y)
+        dlogp = - self._delegate_transform.log_abs_det_jacobian(x, y)
+        return x, dlogp[..., None]

--- a/tests/nn/flow/test_inverted.py
+++ b/tests/nn/flow/test_inverted.py
@@ -16,7 +16,8 @@ from bgflow.nn import flow
     flow.SplitFlow(1),
     flow.SplitFlow(1,1),
     flow.TriuFlow(2),
-    flow.InvertiblePPPP(2)
+    flow.InvertiblePPPP(2),
+    flow.TorchTransform(torch.distributions.IndependentTransform(torch.distributions.SigmoidTransform(), 1))
 ])
 def simpleflow2d(request):
     return request.param
@@ -25,7 +26,7 @@ def simpleflow2d(request):
 def test_inverse(simpleflow2d):
     """Test inverse and inverse logDet of simple 2d flow blocks."""
     inverse = flow.InverseFlow(simpleflow2d)
-    x = torch.tensor([[1.,2.]])
+    x = torch.tensor([[1., 2.]])
     *y, dlogp = simpleflow2d._forward(x)
     x2, dlogpinv = inverse._forward(*y)
     assert (dlogp + dlogpinv).detach().numpy() == pytest.approx(0.0, abs=1e-6)
@@ -33,6 +34,6 @@ def test_inverse(simpleflow2d):
 
     # test dimensions
     assert x2.shape == x.shape
-    assert dlogp.shape == x[...,0,None].shape
-    assert dlogpinv.shape == x[...,0,None].shape
+    assert dlogp.shape == x[..., 0, None].shape
+    assert dlogpinv.shape == x[..., 0, None].shape
 

--- a/tests/nn/flow/test_torchtransform.py
+++ b/tests/nn/flow/test_torchtransform.py
@@ -1,0 +1,25 @@
+
+import torch
+from torch.distributions import SigmoidTransform, AffineTransform, IndependentTransform
+from bgflow import TorchTransform, SequentialFlow, BentIdentity
+
+
+def test_torch_transform(ctx):
+    """try using torch.Transform in combination with bgflow.Flow"""
+    x = torch.torch.randn(10, 3, **ctx)
+    flow = SequentialFlow([
+        TorchTransform(IndependentTransform(SigmoidTransform(), 1)),
+        TorchTransform(
+                AffineTransform(
+                    loc=torch.randn(3, **ctx),
+                    scale=torch.randn(3, **ctx), event_dim=1
+                ),
+        ),
+        BentIdentity(),
+        # test the reinterpret_batch_ndims arguments
+        TorchTransform(SigmoidTransform(), 1)
+    ])
+    z, dlogp = flow.forward(x)
+    y, neg_dlogp = flow.forward(z, inverse=True)
+    assert torch.allclose(x, y, atol=1e-5)
+    assert torch.allclose(dlogp, -neg_dlogp, atol=1e-5)


### PR DESCRIPTION
This has been on my list for a while. 
A simple change that allows us to use all the invertible transforms that are already implemented in [torch](https://pytorch.org/docs/stable/distributions.html#module-torch.distributions.transforms).

For usage examples, see the tests.

@jonkhler Can we merge this quickly - I need it for the revision?