### PR TITLE
fix small bug in BoltzmannGenerator sample method

### DIFF
--- a/bgflow/bg.py
+++ b/bgflow/bg.py
@@ -90,8 +90,8 @@ class BoltzmannGenerator(Energy, Sampler):
         z = self._prior.sample(n_samples, temperature=temperature)
         if isinstance(z, torch.Tensor):
             z = (z,)
-        *results, dlogp = self._flow(*z, temperature=temperature)
-        results = list(results)
+        *x, dlogp = self._flow(*z, temperature=temperature)
+        results = list(x)
 
         if with_latent:
             results.append(*z)
@@ -101,7 +101,7 @@ class BoltzmannGenerator(Energy, Sampler):
             energy = self._prior.energy(*z, temperature=temperature) + dlogp
             results.append(energy)
         if with_log_weights or with_weights:
-            target_energy = self._target.energy(*results, temperature=temperature)
+            target_energy = self._target.energy(*x, temperature=temperature)
             bg_energy = self._prior.energy(*z, temperature=temperature) + dlogp
             log_weights = bg_energy - target_energy
             if with_log_weights:


### PR DESCRIPTION
Calling e.g. `generator.sample(n_samples, with_energy=True, with_weights=True)` was giving an error, with this fix it works.
Please @Olllom have a look and see if this fix is OK or if it's better to do it in another way.