### PR TITLE
sampler refactoring to immutable dataclasses

### DIFF
--- a/bgflow/distribution/sampling/_iterative_helpers.py
+++ b/bgflow/distribution/sampling/_iterative_helpers.py
@@ -1,0 +1,97 @@
+"""Helper classes and functions for iterative samplers."""
+
+import torch
+
+
+__all__ = ["AbstractSamplerState", "default_set_samples_hook", "default_extract_sample_hook"]
+
+
+class AbstractSamplerState:
+    """Defines the interface for implementations of the internal state of iterative samplers."""
+
+    def as_dict(self):
+        """Return a dictionary representing this instance. The dictionary has to define the
+        keys that are used within `SamplerStep`s of an `IterativeSampler`, such as "samples", "energies", ...
+        """
+        raise NotImplementedError()
+
+    def _replace(self, **kwargs):
+        """Return a new object with changed fields.
+        This function has to support all the keys that are used
+        within `SamplerStep`s of an `IterativeSampler` as well as the keys "energies_up_to_date" and
+        "forces_up_to_date"
+        """
+        raise NotImplementedError()
+
+    def evaluate_energy_force(self, energy_model, evaluate_energies=True, evaluate_forces=True):
+        """Return a new state with updated energies/forces."""
+        state = self.as_dict()
+        evaluate_energies = evaluate_energies and not state["energies_up_to_date"]
+        energies = energy_model.energy(*state["samples"])[..., 0] if evaluate_energies else state["energies"]
+
+        evaluate_forces = evaluate_forces and not state["forces_up_to_date"]
+        forces = energy_model.force(*state["samples"]) if evaluate_forces else state["forces"]
+        return self.replace(energies=energies, forces=forces)
+
+    def replace(self, **kwargs):
+        """Return a new state with updated fields."""
+
+        # keep track of energies and forces
+        state_dict = self.as_dict()
+        if "energies" in kwargs:
+            kwargs = {**kwargs, "energies_up_to_date": True}
+        elif "samples" in kwargs:
+            kwargs = {**kwargs, "energies_up_to_date": False}
+        if "forces" in kwargs:
+            kwargs = {**kwargs, "forces_up_to_date": True}
+        elif "samples" in kwargs:
+            kwargs = {**kwargs, "forces_up_to_date": False}
+
+        # map to primary unit cell
+        box_vectors = None
+        if "box_vectors" in kwargs:
+            box_vectors = kwargs["box_vectors"]
+        elif "box_vectors" in state_dict:
+            box_vectors = state_dict["box_vectors"]
+        if "samples" in kwargs and box_vectors is not None:
+            kwargs = {
+                **kwargs,
+                "samples": tuple(
+                    _map_to_primary_cell(x, cell)
+                    for x, cell in zip(kwargs["samples"], box_vectors)
+                )
+            }
+        return self._replace(**kwargs)
+
+
+def default_set_samples_hook(x):
+    """by default, use samples as is"""
+    return x
+
+
+def default_extract_sample_hook(state: AbstractSamplerState):
+    """Default extraction of samples from a SamplerState."""
+    return state.as_dict()["samples"]
+
+
+def _bmv(m, bv):
+    """Batched matrix-vector multiply."""
+    return torch.einsum("ij,...j->...i", m, bv)
+
+
+def _map_to_primary_cell(x, cell):
+    """Map coordinates to the primary unit cell of a periodic lattice.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        n-dimensional coordinates of shape (..., n), where n is the spatial dimension and ... denote an
+        arbitrary number of batch dimensions.
+    cell : torch.Tensor
+        Lattice vectors (column-wise). Has to be upper triangular.
+    """
+    if cell is None:
+        return x
+    n = _bmv(torch.inverse(cell), x)
+    n = torch.floor(n)
+    return x - _bmv(cell, n)

--- a/bgflow/distribution/sampling/mcmc.py
+++ b/bgflow/distribution/sampling/mcmc.py
@@ -17,6 +17,7 @@ import torch
 from ..energy import Energy
 from .base import Sampler
 from .iterative import SamplerStep, IterativeSampler, SamplerState
+from ._iterative_helpers import default_set_samples_hook
 
 
 __all__ = [
@@ -38,9 +39,10 @@ class GaussianProposal(torch.nn.Module):
         self._noise_std = noise_std
 
     def forward(self, state: SamplerState) -> Tuple[SamplerState, float]:
-        proposed_state = state.copy()  # shallow copy
-        proposed_state.samples = [x + torch.randn_like(x) * self._noise_std for x in state.samples]
         delta_log_prob = 0.0  # symmetric density
+        proposed_state = state.replace(
+            samples=tuple(x + torch.randn_like(x) * self._noise_std for x in state.as_dict()["samples"])
+        )
         return proposed_state, delta_log_prob
 
 
@@ -68,18 +70,17 @@ class LatentProposal(torch.nn.Module):
         self.flow_kwargs = flow_kwargs
 
     def forward(self, state: SamplerState) -> Tuple[SamplerState, torch.Tensor]:
-        proposed_state = state.copy()  # shallow copy
-        *proposed_state.samples, logdet_inverse = self.flow.forward(
-            *state.samples, inverse=True, **self.flow_kwargs
+        *z, logdet_inverse = self.flow.forward(
+            *state.as_dict()["samples"], inverse=True, **self.flow_kwargs
         )
-        proposed_state, delta_log_prob = self.base_proposal.forward(proposed_state)
-        *proposed_state.samples, logdet_forward = self.flow.forward(*proposed_state.samples)
+        proposed_latent, delta_log_prob = self.base_proposal.forward(state.replace(samples=z))
+        *proposed_samples, logdet_forward = self.flow.forward(*proposed_latent.as_dict()["samples"])
         # g(x|x') = g(x|z') = p_z (F_{zx}^{-1}(x)  | z') * log | det J_{zx}^{-1} (x) |
         # log g(x|x') = log p(z|z') + logabsdet J_{zx}^-1 (x)
         # log g(x'|x) = log p(z'|z) + logabsdet J_{zx}^-1 (x')
         # log g(x'|x) - log g(x|x') = log p(z|z') - log p(z|z') - logabsdet_forward - logsabdet_inverse
         delta_log_prob = delta_log_prob - (logdet_forward + logdet_inverse)
-        return proposed_state, delta_log_prob[:, 0]
+        return proposed_latent.replace(samples=proposed_samples), delta_log_prob[:, 0]
 
 
 class MCMCStep(SamplerStep):
@@ -101,24 +102,24 @@ class MCMCStep(SamplerStep):
 
     def _step(self, state: SamplerState) -> SamplerState:
         # compute current energies
-        if state.needs_update(check_energies=True, check_forces=False):
-            state.energies = self.target_energy.energy(*state.samples)
-        current_energies = state.energies[..., 0]
+        state = state.evaluate_energy_force(self.target_energy, evaluate_forces=False)
         # make a proposal
         proposed_state, delta_log_prob = self.proposal.forward(state)
-        proposed_energies = self.target_energy.energy(*proposed_state.samples)[..., 0]
+        proposed_state = proposed_state.evaluate_energy_force(self.target_energy, evaluate_forces=False)
         # accept according to Metropolis criterion
+        new_dict = proposed_state.as_dict()
+        old_dict = state.as_dict()
         accept = metropolis_accept(
-            current_energies=current_energies/self.target_temperatures,
-            proposed_energies=proposed_energies/self.target_temperatures,
+            current_energies=old_dict["energies"]/self.target_temperatures,
+            proposed_energies=new_dict["energies"]/self.target_temperatures,
             proposal_delta_log_prob=delta_log_prob
         )
-        state.samples = [
-            torch.where(accept[..., None], new, old)
-            for new, old in zip(proposed_state.samples, state.samples)
-        ]
-        state.energies = torch.where(accept, proposed_energies, current_energies)[...,None]
-        return state
+        return state.replace(
+            samples=tuple(
+                torch.where(accept[..., None], new, old) for new, old in zip(new_dict["samples"], old_dict["samples"])
+            ),
+            energies=torch.where(accept, new_dict["energies"], old_dict["energies"])
+        )
 
 
 class GaussianMCMCSampler(IterativeSampler):
@@ -159,11 +160,11 @@ class GaussianMCMCSampler(IterativeSampler):
     ):
         # first, some things to ensure backwards compatibility
         # apply the box constraint function whenever samples are set
-        set_samples_hook = lambda x: x
+        set_samples_hook = default_set_samples_hook
         if box_constraint is not None:
             set_samples_hook = lambda samples: [box_constraint(x) for x in samples]
-        init_state = init_state if isinstance(init_state, SamplerState) else SamplerState(init_state)
-        init_state.set_samples_hook = set_samples_hook
+        if not isinstance(init_state, SamplerState):
+            init_state = SamplerState(samples=init_state, set_samples_hook=set_samples_hook)
         # flatten batches before returning
         if return_hook is None:
             return_hook = lambda samples: [

--- a/tests/distribution/sampling/test_iterative.py
+++ b/tests/distribution/sampling/test_iterative.py
@@ -2,13 +2,17 @@
 
 import torch
 from bgflow import IterativeSampler, SamplerState, SamplerStep
+from bgflow.distribution.sampling._iterative_helpers import AbstractSamplerState
 
 
 class AddOne(SamplerStep):
-    def _step(self, state):
-        for i in range(len(state.samples)):
-            state.samples[i] = state.samples[i] + 1.0
-        return state
+    def _step(self, state: AbstractSamplerState):
+        statedict = state.as_dict()
+        samples = tuple(
+            x + 1.0
+            for x in statedict["samples"]
+        )
+        return state.replace(samples=samples)
 
 
 def test_iterative_sampler(ctx):
@@ -33,8 +37,4 @@ def test_iterative_sampler(ctx):
     for batch in sampler:  # only called once
         assert torch.allclose(batch.samples[0], torch.tensor([[27., 27.]], **ctx))
     sampler.max_iterations = None
-
-
-
-
 

--- a/tests/distribution/sampling/test_iterative_helpers.py
+++ b/tests/distribution/sampling/test_iterative_helpers.py
@@ -1,0 +1,19 @@
+
+import torch
+from bgflow.distribution.sampling._iterative_helpers import _map_to_primary_cell
+
+
+def test_map_to_primary_cell():
+    cell = torch.eye(3)
+    x = torch.tensor([[1.2, -0.1, 4.5]])
+    assert torch.allclose(_map_to_primary_cell(x, cell), torch.tensor([[0.2, 0.9, 0.5]]))
+
+    cell = torch.tensor(
+        [
+            [1.0, 2.0, 0.0],
+            [0.0, 2.0, 0.0],
+            [0.0, 0.0, 1.0]
+        ]
+    )
+    assert torch.allclose(_map_to_primary_cell(x, cell), torch.tensor([[2.2, 1.9, 0.5]]))
+


### PR DESCRIPTION
@jonkhler 
This is a follow-up to our discussion about the sampler states.
I've tried to also incorporate some thought about a discussion I had with Felix.

The new design is as follows: A sampler state can be any class that satisfies the interface of `_iterative_helpers.AbstractSamplerState`. That is:
- it can return a modified shallow copy of itself through a `replace` method
- it can evaluate energies and forces given by some energy module through a method `evaluate_energies_forces`
- it can dress itself as a dictionary through an `as_dict` method

The "default implementation", `iterative.SamplerState`, is a thin wrapper around a dataclass.
The reason for this additional level of abstraction is that we can wrap the cgnet data structures into the same interface.

Let me know what you think.