### PR TITLE
added warning on zero initialization

### DIFF
--- a/bgflow/factory/generator_builder.py
+++ b/bgflow/factory/generator_builder.py
@@ -173,6 +173,7 @@ class BoltzmannGeneratorBuilder:
         """
         flow = SequentialFlow(self.layers)
         if zero_parameters:
+            warnings.warn("Initializing the flow with zeros makes it much less flexible", UserWarning)
             for p in flow.parameters():
                 p.data.zero_()
         return flow


### PR DESCRIPTION
as discussed with @jonkhler, when flow parameters are initialized to zero most of them will remain zeros, so it's probably better to raise a warning. Nevertheless, it can still be useful, as it was for the LREX paper, so I would keep the option