### PR TITLE
Fixed the setup.py 

### DIFF
--- a/bgflow/distribution/energy/multi_double_well_potential.py
+++ b/bgflow/distribution/energy/multi_double_well_potential.py
@@ -5,7 +5,7 @@ __all__ = ["MultiDoubleWellPotential"]
 
 
 class MultiDoubleWellPotential(Energy):
-    """Energy for a many particle system with pair wise double-well interactions.
+    r"""Energy for a many particle system with pair wise double-well interactions.
     The energy of the double-well is given via
 
     .. math::

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+# Mandatory dependencies
+torch
+einops
+numpy
+
+# Optional dependencies
+# matplotlib       # for plotting
+# pytest           # for testing
+# nflows           # for Neural Spline Flows
+# torchdiffeq      # for neural ODEs
+# ANODE            # for neural ODEs
+# openmm           # for molecular mechanics energies
+# ase              # for atomic simulation environment
+# xtb-python       # for GFN quantum energies
+# netCDF4          # for ReplayBufferReporter
+# jax              # for implicit flows
+# jax2torch        # for jax-to-torch bridges
+# allegro          # for GNNs
+# nequip           # for GNNs
+# bgmol            # for examples
+

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,10 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.RawConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        # parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
- Replaced  `SafeConfigParser` with `RawConfigParser`.   `SafeConfigParser` was  [ replicated](https://docs.python.org/3/whatsnew/changelog.html#python-3-11-0-alpha-1) since 3.2.. 
- Added `r""" ... """` prefix in front of the docstring in ` /home/your_user_name/bgflow/bgflow/distribution/energy/multi_double_well_potential.py` to stop the `SyntaxWarning` caused by using the LaTeX command `\cdot`. 